### PR TITLE
Update for Anaconda CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Ignore all files and folders in root
 *
+!/abs.yaml
 !/conda-forge.yml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'

--- a/recipe/CMakeLists.txt
+++ b/recipe/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 project(azure-storage-common-cpp-dependent-project LANGUAGES CXX)
 
 find_package(azure-storage-common-cpp CONFIG REQUIRED)

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,6 +8,8 @@ mkdir build
 cd build
 cmake %CMAKE_ARGS% ^
   -G Ninja ^
+  -D CMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+  -D CMAKE_BUILD_TYPE=Release ^
   -D BUILD_SHARED_LIBS=ON ^
   -D BUILD_TRANSPORT_WINHTTP=ON ^
   ..

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,8 +18,9 @@ cd sdk/storage/azure-storage-common
 mkdir build
 cd build
 cmake $CMAKE_ARGS \
-  -D CMAKE_BUILD_TYPE=Release \
   -G Ninja \
+  -D CMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -D CMAKE_BUILD_TYPE=Release \
   -D BUILD_SHARED_LIBS=ON \
   -D BUILD_TRANSPORT_CURL=ON \
   ..

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set version = "12.10.0" %}
-{% set sha256 = "84e165267995b8d10060abe1c2b65b3238eccea3f11222b5ae36042a1d1ae07f" %}
 
 package:
   name: azure-storage-common-cpp
@@ -7,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-storage-common_{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 84e165267995b8d10060abe1c2b65b3238eccea3f11222b5ae36042a1d1ae07f
 
 build:
   number: 0
@@ -18,14 +17,12 @@ build:
 requirements:
   build:
     - {{ compiler("cxx") }}
-    - {{ stdlib("c") }}
     - cmake
     - ninja
   host:
-    # azure-core-cpp is pinned in conda-forge-pinning-feedstock
-    - azure-core-cpp
-    - libxml2  # [not win]
-    - openssl  # [not win]
+    - azure-core-cpp 1.14
+    - libxml2 {{ libxml2 }}  # [unix]
+    - openssl {{ openssl }}  # [unix]
 
 test:
   requires:


### PR DESCRIPTION
azure-storage-common-cpp 12.10.0

**Destination channel:** defaults

### Links

- [PKG-8077](https://anaconda.atlassian.net/browse/PKG-8077)
- [Upstream repository](https://github.com/Azure/azure-sdk-for-cpp/tree/azure-storage-common_12.10.0/sdk/storage/azure-storage-common)
- Relevant dependency PRs:
  - AnacondaRecipes/wil-feedstock#1
  - AnacondaRecipes/azure-core-cpp-feedstock#1

### Explanation of changes:

- Initial build of forked conda-forge recipe


[PKG-8077]: https://anaconda.atlassian.net/browse/PKG-8077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ